### PR TITLE
fix(pipelines): correct svg_montage_path key typo in qsiprep config

### DIFF
--- a/pipelines/qsiprep/qsiprep_qc.json
+++ b/pipelines/qsiprep/qsiprep_qc.json
@@ -5,12 +5,12 @@
         "svg_montage_path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_seg_brainmask.svg"
     },
     "t1_2_mni_qc": {
-        "svg_montage_,path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_t1_2_mni.svg"
+        "svg_montage_path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_t1_2_mni.svg"
     },
     "sdc_wf_qc": {
-        "svg_montage_,path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_ses-01_desc-sdc_b0.svg"
+        "svg_montage_path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_ses-01_desc-sdc_b0.svg"
     },
     "coreg_wf_qc": {
-        "svg_montage_,path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_ses-01_coreg.svg"
+        "svg_montage_path": "../sample_data/derivatives/qsiprep/0.22.0/output/sub-ED01/figures/sub-ED01_ses-01_coreg.svg"
     }
 }


### PR DESCRIPTION
the key `"svg_montage_,path"` (with a stray comma) appears in three QC tasks in `qsiprep_qc.json`:
- `t1_2_mni_qc`
- `sdc_wf_qc`  
- `coreg_wf_qc`

because the key doesn't match the `QCTask` pydantic model field name, the SVG montage paths are silently ignored and those panels show "SVG montage not found" even when the files exist. renamed all three to `"svg_montage_path"`.

`anat_wf_qc` was already correct.