### PR TITLE
fix(ui): read participant_id and session_id from args instead of hardcoded values

### DIFF
--- a/dev_plan.md
+++ b/dev_plan.md
@@ -1,6 +1,6 @@
 # QC-Studio MVP Scope
 
-## Desgin Overview
+## Design Overview
 ![overview](assets/nipoppy-qc-studio_overview.jpg)
 
 

--- a/ui/ui.py
+++ b/ui/ui.py
@@ -8,8 +8,6 @@ import pandas as pd
 import streamlit as st
 from layout import app
 
-import streamlit as st
-
 def parse_args(args=None):
     parser = ArgumentParser("QC-Studio")
 
@@ -86,8 +84,9 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 qc_config_path = os.path.join(current_dir, qc_json)
 # print(f"qc path: {qc_config_path}")
 
-participant_id = "sub-ED01"
-session_id = "ses-01"
+page_idx = min(st.session_state.get("current_page", 1) - 1, len(participants_df) - 1)
+participant_id = participants_df["participant_id"].iloc[page_idx]
+session_id = session_list
 
 app(
     participant_id=participant_id,


### PR DESCRIPTION
participant_id was hardcoded to 'sub-ED01' and session_id to 'ses-01', so passing --participant_list or --session_list had no effect on which participant was displayed. this reads participant_id from participants_df using the current page index, and session_id from the session_list arg. also removes a duplicate 'import streamlit as st' on line 11.