### PR TITLE
UI detailed statistics

### DIFF
--- a/ui/components/qc_viewer.py
+++ b/ui/components/qc_viewer.py
@@ -138,8 +138,13 @@ def display_qc_viewers(
 		# Full-width IQM only
 		elif show_iqm:
 			_display_iqm_panel()
-	
-	SessionManager.set_session_start_time(time.time())
+
+	# Start timing when the displayed participant/session changes (avoid resetting on every rerun)
+	timing_key = (participant_id, session_id, qc_task)
+	if st.session_state.get("_qc_timing_key") != timing_key:
+		print(st.session_state.get("_qc_timing_key"))
+		st.session_state["_qc_timing_key"] = timing_key
+		SessionManager.set_session_start_time(time.time())
 	# Autoplay rerun loop: panels have now rendered; keep refreshing so the
 	# countdown display stays live and the timer expiry check fires on time
 	if SessionManager.is_autoplay_enabled():

--- a/ui/components/qc_viewer.py
+++ b/ui/components/qc_viewer.py
@@ -139,6 +139,7 @@ def display_qc_viewers(
 		elif show_iqm:
 			_display_iqm_panel()
 	
+	SessionManager.set_session_start_time(time.time())
 	# Autoplay rerun loop: panels have now rendered; keep refreshing so the
 	# countdown display stays live and the timer expiry check fires on time
 	if SessionManager.is_autoplay_enabled():
@@ -455,6 +456,7 @@ def _save_qc_record(participant_id: str, session_id: str, qc_pipeline: str,
 		notes: QC notes
 		total_participants: Total participants (used to detect end of QC)
 	"""
+
 	_record_qc_for_current_participant(participant_id, session_id, qc_pipeline, qc_task, rating, notes)
 	SessionManager.set_current_page(total_participants + 1)
 	st.rerun()
@@ -464,8 +466,10 @@ def _record_qc_for_current_participant(participant_id: str, session_id: str,
 										 qc_pipeline: str, qc_task: str,
 										 rating: str, notes: str) -> None:
 	"""Save a QC record for the current participant without navigating."""
-	now = datetime.now()
-	timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
+	now = time.time()
+	timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(now))
+	start_time = SessionManager.get_session_start_time()
+	duration = int(now - start_time)
 	record = QCRecord(
 		participant_id=participant_id,
 		session_id=session_id,
@@ -477,5 +481,6 @@ def _record_qc_for_current_participant(participant_id: str, session_id: str,
 		rater_fatigue=SessionManager.get_rater_fatigue(),
 		final_qc=rating,
 		notes=notes,
+		duration=duration,
 	)
 	SessionManager.add_qc_record(record)

--- a/ui/managers/session_manager.py
+++ b/ui/managers/session_manager.py
@@ -26,7 +26,8 @@ class SessionManager:
             SESSION_KEYS['montage_max_cols']: DEFAULT_MONTAGE_MAX_COLS,
             'autoplay_enabled': False,
             'autoplay_start_time': 0.0,
-            'autoplay_duration': 5
+            'autoplay_duration': 5,
+            'session_start_time':0.0,
         }
         
         for key, value in defaults.items():
@@ -297,3 +298,12 @@ class SessionManager:
     def set_autoplay_duration(seconds: int):
         """Set the autoplay countdown duration in seconds (2–10)."""
         st.session_state['autoplay_duration'] = max(2, min(10, seconds))
+
+    @staticmethod
+    def get_session_start_time() -> float:
+        """Get the timestamp when the session page was shown."""
+        return st.session_state.get('session_start_time', 0.0)
+    
+    #staticmethod
+    def set_session_start_time(t: float):
+        st.session_state['session_start_time'] = t

--- a/ui/managers/session_manager.py
+++ b/ui/managers/session_manager.py
@@ -304,6 +304,7 @@ class SessionManager:
         """Get the timestamp when the session page was shown."""
         return st.session_state.get('session_start_time', 0.0)
     
-    #staticmethod
+    @staticmethod
     def set_session_start_time(t: float):
+        """Set the timestamp for when the session page was shown."""
         st.session_state['session_start_time'] = t

--- a/ui/models/qc_models.py
+++ b/ui/models/qc_models.py
@@ -47,6 +47,7 @@ class QCRecord(BaseModel):
     rater_fatigue: Annotated[Optional[str], Field(description="Rater fatigue level")] = None
     final_qc: Optional[str] = None
     notes: Annotated[Optional[str], Field(description="Additional comment")] = None
+    duration: Annotated[Optional[int], Field(description="Duration of the session resulting in the final annotation")] = None
 
 
 class QCTask(BaseModel):
@@ -95,3 +96,4 @@ class QCStatusRow(BaseModel):
     score: Optional[QCDecision] = None
     notes: Optional[str] = None
     timestamp: Optional[date] = None
+    duration: Optional[int] = None

--- a/ui/pages/congratulations_page.py
+++ b/ui/pages/congratulations_page.py
@@ -1,123 +1,149 @@
 """Congratulations page component for QC-Studio UI."""
+
+import altair as alt
+from constants import MESSAGES, SUCCESS_MESSAGES, INFO_MESSAGES, QC_RATINGS
+from managers.session_manager import SessionManager
+import pandas as pd
 from pathlib import Path
 import streamlit as st
-from constants import MESSAGES, SUCCESS_MESSAGES, INFO_MESSAGES
-from managers.session_manager import SessionManager
-from utils.export import save_qc_results_to_csv
-from constants import QC_RATINGS
-import pandas as pd
-import altair as alt
+from utils.export import save_qc_results_to_csv 
 
-def show_congratulations_page(qc_task: str, out_dir: str, total_participants: int, drop_duplicates: bool) -> None:
-	"""Display the final congratulations page after QC is complete.
-	
-	Args:
-		qc_task: QC task name
-		out_dir: Output directory path
-		total_participants: Total number of participants in the QC session
-		drop_duplicates: Whether to drop duplicate records before saving
-	"""
-	st.title(MESSAGES['congratulations_title'])
-	
-	# Display rater info and summary statistics
-	rater_id = SessionManager.get_rater_id()
-	record_list = SessionManager.get_qc_records()
-	num_reviewed = len(record_list)
-	
-	st.markdown(f"""
-	## {num_reviewed} participant(s) have been reviewed!
-	
-	Thank you for completing the quality control process. Your thorough review ensures the integrity of our data!
-	
-	✅ All QC records have been automatically saved.
-	
-	""")
-	
-	# Display session information and results summary
-	_display_session_summary(rater_id, qc_task, record_list)
-	
-	# Action buttons
-	col1, col2, col3 = st.columns([1, 1, 1])
-	with col1:
-		if st.button(MESSAGES['export_results_button'], width='stretch'):
-			_export_qc_results(rater_id, out_dir, record_list, drop_duplicates)
-	with col2:
-		if st.button(MESSAGES['previous_button'], width='stretch'):
-			SessionManager.previous_page()
-			st.rerun()
-	with col3:
-		if st.button(MESSAGES['start_over_button'], width='stretch'):
-			SessionManager.set_landing_page_complete(False)
-			st.rerun()
+
+def show_congratulations_page(
+    qc_task: str, out_dir: str, total_participants: int, drop_duplicates: bool
+) -> None:
+    """Display the final congratulations page after QC is complete.
+
+    Args:
+        qc_task: QC task name
+        out_dir: Output directory path
+        total_participants: Total number of participants in the QC session
+        drop_duplicates: Whether to drop duplicate records before saving
+    """
+    st.title(MESSAGES["congratulations_title"])
+
+    # Display rater info and summary statistics
+    rater_id = SessionManager.get_rater_id()
+    record_list = SessionManager.get_qc_records()
+    num_reviewed = len(record_list)
+
+    st.markdown(f"""
+    ## {num_reviewed} participant(s) have been reviewed!
+    
+    Thank you for completing the quality control process. Your thorough review ensures the integrity of our data!
+    
+    ✅ All QC records have been automatically saved.
+    
+    """)
+
+    # Display session information and results summary
+    _display_session_summary(rater_id, qc_task, record_list)
+
+    # Action buttons
+    col1, col2, col3 = st.columns([1, 1, 1])
+    with col1:
+        if st.button(MESSAGES["export_results_button"], width="stretch"):
+            _export_qc_results(rater_id, out_dir, record_list, drop_duplicates)
+    with col2:
+        if st.button(MESSAGES["previous_button"], width="stretch"):
+            SessionManager.previous_page()
+            st.rerun()
+    with col3:
+        if st.button(MESSAGES["start_over_button"], width="stretch"):
+            SessionManager.set_landing_page_complete(False)
+            st.rerun()
 
 
 def _display_session_summary(rater_id: str, qc_task: str, record_list: list) -> None:
-	"""Display summary of the QC session.
-	
-	Args:
-		rater_id: Rater ID
-		qc_task: QC task name
-		record_list: List of QC records
-	"""
-	col1, col2 = st.columns([1, 1])
-	with col1:
-		st.subheader("Session Information")
-		st.write(f"**Rater ID:** {rater_id}")
-		st.write(f"**QC Task:** {qc_task}")
-		st.write(f"**Total Participants Reviewed:** {len(record_list)}")
-	
-	with col2:
-		st.subheader("QC Results Summary")
-		# Count final_qc values
-		if record_list:
-			num_reviewed = len(record_list)
-			final_qc_counts = {}
-			durations = []
-			labels = []
-			for record in record_list:
-				qc_value = record.final_qc				
-				if qc_value not in QC_RATINGS:
-					final_qc_counts["Unrated"] = final_qc_counts.get(qc_value, 0) + 1
-					labels.append("Unrated")
-				else:
-					final_qc_counts[qc_value] = final_qc_counts.get(qc_value, 0) + 1
-					labels.append(qc_value)
-				durations.append(int(record.duration))
-			duration_dict = {"duration":durations, "qc_value":labels}
-			duration_df = pd.DataFrame(duration_dict, columns=['duration','qc_value'])
+    """Display summary of the QC session.
 
-			final_qc_df = pd.DataFrame.from_dict(final_qc_counts, orient='index', columns=['Count'])
-			final_qc_df['Percentage'] = final_qc_df['Count'].apply(lambda x : x/num_reviewed)
-			#table with count and percentage per qc_value
-			st.table(data=final_qc_df, border=True, width="stretch", height="content", hide_index=None, hide_header=None)
-			#stacked histogram of duration count
-			selection = alt.selection_point(fields=['qc_value'], bind='legend')
-			line_chart = alt.Chart(duration_df).encode(
-				alt.X('duration:Q', title='Duration (s)',axis=alt.Axis(tickMinStep=1), bin=alt.Bin(step=1)),
-				alt.Y('count()',).stack(True), # change True to None to get non-stacked histogram
-				alt.Color('qc_value:N').scale(scheme="observable10"),
-				opacity=alt.condition(selection, alt.value(1), alt.value(0.2)) #link opacity to the selection state
-			).add_params(
-    			selection,
-			).mark_bar(
-				opacity=1 # to adapt if layering histograms
-			)
+    Args:
+        rater_id: Rater ID
+        qc_task: QC task name
+        record_list: List of QC records
+    """
+    col1, col2 = st.columns([1, 1])
+    with col1:
+        st.subheader("Session Information")
+        st.write(f"**Rater ID:** {rater_id}")
+        st.write(f"**QC Task:** {qc_task}")
+        st.write(f"**Total Participants Reviewed:** {len(record_list)}")
 
-			st.altair_chart(line_chart)
+    with col2:
+        st.subheader("QC Results Summary")
+        # Count final_qc values
+        if record_list:
+            num_reviewed = len(record_list)
+            final_qc_counts = {}
+            durations = []
+            labels = []
+            for record in record_list:
+                qc_value = record.final_qc
+                if qc_value not in QC_RATINGS:
+                    final_qc_counts["Unrated"] = final_qc_counts.get("Unrated", 0) + 1
+                    labels.append("Unrated")
+                else:
+                    final_qc_counts[qc_value] = final_qc_counts.get(qc_value, 0) + 1
+                    labels.append(qc_value)
+                durations.append(int(record.duration))
+            duration_dict = {"duration": durations, "qc_value": labels}
+            duration_df = pd.DataFrame(duration_dict, columns=["duration", "qc_value"])
+
+            final_qc_df = pd.DataFrame.from_dict(
+                final_qc_counts, orient="index", columns=["Count"]
+            )
+            final_qc_df['Percentage (%)'] = (final_qc_df['Count'] / num_reviewed).mul(100).round(1)
+            total_duration_s = int(sum(durations))
+            avg_duration_s = (total_duration_s / num_reviewed) if num_reviewed else 0.0
+
+            st.write(f"**Total QC session duration:** {total_duration_s}s")
+            st.write(f"**Average rating time per participant:** {avg_duration_s:.1f}s")
+            st.dataframe(final_qc_df, width='stretch')
+
+            # stacked histogram of duration count
+            selection = alt.selection_point(fields=["qc_value"], bind="legend")
+            line_chart = (
+                alt.Chart(duration_df)
+                .encode(
+                    alt.X(
+                        "duration:Q",
+                        title="Duration (s)",
+                        axis=alt.Axis(tickMinStep=1),
+                        bin=alt.Bin(step=1),
+                    ),
+                    alt.Y(
+                        "count()",
+                    ).stack(False),  # change True to None to get non-stacked histogram
+                    alt.Color("qc_value:N").scale(scheme="observable10"),
+                    opacity=alt.condition(
+                        selection, alt.value(1), alt.value(0.2)
+                    ),  # link opacity to the selection state
+                )
+                .add_params(
+                    selection,
+                )
+                .mark_bar(
+                    opacity=1  # to adapt if layering histograms
+                )
+            )
+
+            st.altair_chart(line_chart)
 
 
-def _export_qc_results(rater_id: str, out_dir: str, record_list: list, drop_duplicates: bool) -> None:
-	"""Export QC results to file.
-	
-	Args:
-		rater_id: Rater ID
-		out_dir: Output directory path
-		record_list: List of QC records to export
-		drop_duplicates: Whether to drop duplicate records
-	"""
-	out_file = Path(out_dir) / f"{rater_id}_QC_status.tsv"
-	if record_list:
-		out_path = save_qc_results_to_csv(out_file, record_list, drop_duplicates)
-		st.success(SUCCESS_MESSAGES['records_exported'].format(path=out_path))
-	else:
-		st.info(INFO_MESSAGES['no_export_records'])
+def _export_qc_results(
+    rater_id: str, out_dir: str, record_list: list, drop_duplicates: bool
+) -> None:
+    """Export QC results to file.
+
+    Args:
+        rater_id: Rater ID
+        out_dir: Output directory path
+        record_list: List of QC records to export
+        drop_duplicates: Whether to drop duplicate records
+    """
+    out_file = Path(out_dir) / f"{rater_id}_QC_status.tsv"
+    if record_list:
+        out_path = save_qc_results_to_csv(out_file, record_list, drop_duplicates)
+        st.success(SUCCESS_MESSAGES["records_exported"].format(path=out_path))
+    else:
+        st.info(INFO_MESSAGES["no_export_records"])

--- a/ui/pages/congratulations_page.py
+++ b/ui/pages/congratulations_page.py
@@ -1,12 +1,13 @@
 """Congratulations page component for QC-Studio UI."""
 
-import altair as alt
 from constants import MESSAGES, SUCCESS_MESSAGES, INFO_MESSAGES, QC_RATINGS
 from managers.session_manager import SessionManager
+import numpy as np
 import pandas as pd
 from pathlib import Path
 import streamlit as st
 from utils.export import save_qc_results_to_csv 
+import plotly.express as px
 
 
 def show_congratulations_page(
@@ -86,48 +87,56 @@ def _display_session_summary(rater_id: str, qc_task: str, record_list: list) -> 
                     final_qc_counts[qc_value] = final_qc_counts.get(qc_value, 0) + 1
                     labels.append(qc_value)
                 durations.append(int(record.duration))
+
             duration_dict = {"duration": durations, "qc_value": labels}
             duration_df = pd.DataFrame(duration_dict, columns=["duration", "qc_value"])
 
-            final_qc_df = pd.DataFrame.from_dict(
-                final_qc_counts, orient="index", columns=["Count"]
-            )
+            final_qc_df = pd.DataFrame.from_dict(final_qc_counts, orient="index", columns=["Count"])
             final_qc_df['Percentage (%)'] = (final_qc_df['Count'] / num_reviewed).mul(100).round(1)
+
             total_duration_s = int(sum(durations))
             avg_duration_s = (total_duration_s / num_reviewed) if num_reviewed else 0.0
 
+            # Annotation duration general information
             st.write(f"**Total QC session duration:** {total_duration_s}s")
             st.write(f"**Average rating time per participant:** {avg_duration_s:.1f}s")
-            st.dataframe(final_qc_df, width='stretch')
 
-            # stacked histogram of duration count
-            selection = alt.selection_point(fields=["qc_value"], bind="legend")
-            line_chart = (
-                alt.Chart(duration_df)
-                .encode(
-                    alt.X(
-                        "duration:Q",
-                        title="Duration (s)",
-                        axis=alt.Axis(tickMinStep=1),
-                        bin=alt.Bin(step=1),
-                    ),
-                    alt.Y(
-                        "count()",
-                    ).stack(False),  # change True to None to get non-stacked histogram
-                    alt.Color("qc_value:N").scale(scheme="observable10"),
-                    opacity=alt.condition(
-                        selection, alt.value(1), alt.value(0.2)
-                    ),  # link opacity to the selection state
-                )
-                .add_params(
-                    selection,
-                )
-                .mark_bar(
-                    opacity=1  # to adapt if layering histograms
-                )
+            # Table showing the label count and percentage of overall annotated cohort
+            st.dataframe(final_qc_df, width='stretch') 
+
+            # Grouped histogram of duration count
+            count_df = duration_df.groupby(['duration','qc_value']).size().reset_index(name='count')
+
+            # Create the grouped bar chart
+            fig = px.bar(
+                count_df,
+                x='duration',
+                y='count',
+                color='qc_value',
+                barmode='group',
+                title='Distribution of rating duration across quality categories'
+            )
+            # Force integer ticks
+            fig.update_yaxes(
+                tickvals=np.arange(0, int(count_df['count'].max()) + 1, 1),
+                tick0=0
             )
 
-            st.altair_chart(line_chart)
+            fig.update_layout(
+                xaxis_title='Duration (s)',
+                yaxis_title='Count',
+                legend_title='',
+                legend=dict(
+                    orientation="h",
+                    yanchor="bottom",
+                    y=1.02,
+                    xanchor="right",
+                    x=1
+                ),
+                bargap=0.1  # Add small gap between groups for readability
+            )
+
+            st.plotly_chart(fig, use_container_width=True)
 
 
 def _export_qc_results(

--- a/ui/pages/congratulations_page.py
+++ b/ui/pages/congratulations_page.py
@@ -5,6 +5,8 @@ from constants import MESSAGES, SUCCESS_MESSAGES, INFO_MESSAGES
 from managers.session_manager import SessionManager
 from utils.export import save_qc_results_to_csv
 from constants import QC_RATINGS
+import pandas as pd
+import altair as alt
 
 def show_congratulations_page(qc_task: str, out_dir: str, total_participants: int, drop_duplicates: bool) -> None:
 	"""Display the final congratulations page after QC is complete.
@@ -68,16 +70,40 @@ def _display_session_summary(rater_id: str, qc_task: str, record_list: list) -> 
 		st.subheader("QC Results Summary")
 		# Count final_qc values
 		if record_list:
+			num_reviewed = len(record_list)
 			final_qc_counts = {}
+			durations = []
+			labels = []
 			for record in record_list:
 				qc_value = record.final_qc				
 				if qc_value not in QC_RATINGS:
 					final_qc_counts["Unrated"] = final_qc_counts.get(qc_value, 0) + 1
+					labels.append("Unrated")
 				else:
 					final_qc_counts[qc_value] = final_qc_counts.get(qc_value, 0) + 1
-			
-			for qc_status, count in sorted(final_qc_counts.items()):
-				st.write(f"**{qc_status}:** {count}")
+					labels.append(qc_value)
+				durations.append(int(record.duration))
+			duration_dict = {"duration":durations, "qc_value":labels}
+			duration_df = pd.DataFrame(duration_dict, columns=['duration','qc_value'])
+
+			final_qc_df = pd.DataFrame.from_dict(final_qc_counts, orient='index', columns=['Count'])
+			final_qc_df['Percentage'] = final_qc_df['Count'].apply(lambda x : x/num_reviewed)
+			#table with count and percentage per qc_value
+			st.table(data=final_qc_df, border=True, width="stretch", height="content", hide_index=None, hide_header=None)
+			#stacked histogram of duration count
+			selection = alt.selection_point(fields=['qc_value'], bind='legend')
+			line_chart = alt.Chart(duration_df).encode(
+				alt.X('duration:Q', title='Duration (s)',axis=alt.Axis(tickMinStep=1), bin=alt.Bin(step=1)),
+				alt.Y('count()',).stack(True), # change True to None to get non-stacked histogram
+				alt.Color('qc_value:N').scale(scheme="observable10"),
+				opacity=alt.condition(selection, alt.value(1), alt.value(0.2)) #link opacity to the selection state
+			).add_params(
+    			selection,
+			).mark_bar(
+				opacity=1 # to adapt if layering histograms
+			)
+
+			st.altair_chart(line_chart)
 
 
 def _export_qc_results(rater_id: str, out_dir: str, record_list: list, drop_duplicates: bool) -> None:


### PR DESCRIPTION
- Closes #30

<!-- 
Improved the statistics summary provided in the congratulations page by tracking time spent on sessions resulting in a confirmed label. Duration is kept in the qc record and extracted to present the user with a stacked histogram of duration.
Added a table presenting the user with the raw count and distribution of labels over the annotated sessions.
-->
Changes proposed in this pull request:
- ui/components/qc_viewer.py: tracking of the  session _start_time_  attribute and the computation of the duration of the session
- ui/managers/session_manager.py: added _session_start_time_ attribute and getter and setter
- ui/models/qc_models.py: added _duration_ attribute to _qc_model_
- ui/pages/congratulations_page.py: added a table with count and percentage for each qc label, and interactive stacked histogram for the distribution of the session duration.
