### PR TITLE
[ENH] Extract task and run metadata from SVG montage paths

### DIFF
--- a/ui/components/qc_viewer.py
+++ b/ui/components/qc_viewer.py
@@ -6,6 +6,7 @@ import streamlit.components.v1 as components
 import time
 from datetime import datetime, timedelta
 from constants import SVG_HEIGHT, MESSAGES, ERROR_MESSAGES, QC_RATINGS, NIIVUE_SECONDARY_RATIO, VIEW_MODES, OVERLAY_COLORMAPS
+from utils.bids import extract_unique_task_run_from_paths
 from utils.data_loaders import load_svg_data
 from utils.config import parse_qc_config
 from managers.niivue_viewer_manager import NiivueViewerManager, NiivueViewerConfig
@@ -43,6 +44,8 @@ def try_autoplay_advance_if_due(
 	total_participants: int | None,
 	qc_cohort: list | None = None,
 	participant_ids: list | None = None,
+	qc_config_path: str | None = None,
+	substitution_values: dict | None = None,
 ) -> None:
 	"""If autoplay interval elapsed, save ratings and go to next page (or stop at end).
 
@@ -64,11 +67,25 @@ def try_autoplay_advance_if_due(
 	if not tasks:
 		tasks = [qc_task] if qc_task else ["anat_wf_qc"]
 	if SessionManager.get_current_page() < total_participants:
-		_record_all_qc_tasks(participant_id, session_id, qc_pipeline, tasks)
+		_record_all_qc_tasks(
+			participant_id,
+			session_id,
+			qc_pipeline,
+			tasks,
+			qc_config_path=qc_config_path,
+			substitution_values=substitution_values,
+		)
 		SessionManager.next_page()
 		SessionManager.set_autoplay_start_time(time.time())
 	else:
-		_record_all_qc_tasks(participant_id, session_id, qc_pipeline, tasks)
+		_record_all_qc_tasks(
+			participant_id,
+			session_id,
+			qc_pipeline,
+			tasks,
+			qc_config_path=qc_config_path,
+			substitution_values=substitution_values,
+		)
 		if qc_cohort and SessionManager.all_qc_cohort_pages_complete_for_tasks(tasks, qc_cohort):
 			SessionManager.set_current_page(total_participants + 1)
 		elif (
@@ -143,6 +160,8 @@ def _autoplay_fragment_advance_only() -> None:
 		total_participants=ctx.get("total_participants"),
 		qc_cohort=ctx.get("qc_cohort"),
 		participant_ids=ctx.get("participant_ids"),
+		qc_config_path=ctx.get("qc_config_path"),
+		substitution_values=ctx.get("substitution_values"),
 	)
 
 
@@ -424,13 +443,39 @@ def _display_qc_rating_for_task(
 	)
 
 
-def _record_all_qc_tasks(participant_id: str, session_id: str, qc_pipeline: str, qc_tasks: list) -> None:
+def _record_all_qc_tasks(
+	participant_id: str,
+	session_id: str,
+	qc_pipeline: str,
+	qc_tasks: list,
+	qc_config_path=None,
+	substitution_values=None,
+) -> None:
+	"""Record QC ratings and notes for all tasks on the current page."""
 	rver = SessionManager.get_rating_version()
 	nver = SessionManager.get_notes_version()
+
 	for t in qc_tasks:
 		rating = st.session_state.get(f"qc_rating_{t}_{rver}")
 		notes = st.session_state.get(f"qc_notes_{t}_{nver}", "")
-		_record_qc_for_current_participant(participant_id, session_id, qc_pipeline, t, rating, notes)
+
+		task_id = None
+		run_id = None
+		if qc_config_path:
+			qc_config = parse_qc_config(qc_config_path, t, substitution_values)
+			task_id, run_id = extract_unique_task_run_from_paths(
+				qc_config.get("svg_montage_path")
+			)
+		_record_qc_for_current_participant(
+			participant_id=participant_id,
+			session_id=session_id,
+			qc_pipeline=qc_pipeline,
+			qc_task=t,
+			rating=rating,
+			notes=notes,
+			task_id=task_id,
+			run_id=run_id,
+		)
 
 
 def _display_qc_pagination_header(current_page: int, total_participants: int) -> None:
@@ -448,6 +493,8 @@ def _display_qc_pagination_controls(
 	qc_tasks: list,
 	participant_ids: list | None = None,
 	qc_cohort: list | None = None,
+	qc_config_path: str | None = None,
+	substitution_values: dict | None = None,
 ) -> None:
 	"""Sidebar: autoplay, page buttons, save CSV (call inside ``with st.sidebar:``)."""
 	autoplay_col1, autoplay_col2 = st.columns([1, 1])
@@ -493,7 +540,14 @@ def _display_qc_pagination_controls(
 			key="pag_confirm",
 			help=MESSAGES['nav_tooltip_confirm_next'],
 		):
-			_record_all_qc_tasks(participant_id, session_id, qc_pipeline, qc_tasks)
+			_record_all_qc_tasks(
+				participant_id,
+				session_id,
+				qc_pipeline,
+				qc_tasks,
+				qc_config_path=qc_config_path,
+				substitution_values=substitution_values,
+			)
 			if SessionManager.is_autoplay_enabled():
 				SessionManager.set_autoplay_start_time(time.time())
 			elif current_page < total_participants:
@@ -539,6 +593,8 @@ def _display_qc_pagination_controls(
 			total_participants=total_participants,
 			participant_ids=participant_ids,
 			qc_cohort=qc_cohort,
+			qc_config_path=qc_config_path,
+			substitution_values=substitution_values,
 		)
 
 
@@ -551,6 +607,8 @@ def _display_qc_pagination(
 	qc_tasks: list,
 	participant_ids: list | None = None,
 	qc_cohort: list | None = None,
+	qc_config_path: str | None = None,
+	substitution_values: dict | None = None,
 ) -> None:
 	"""Full navigation block (header + controls) for callers that do not inject Subjects between."""
 	_display_qc_pagination_header(current_page, total_participants)
@@ -564,6 +622,8 @@ def _display_qc_pagination(
 		qc_tasks=qc_tasks,
 		participant_ids=participant_ids,
 		qc_cohort=qc_cohort,
+		qc_config_path=qc_config_path,
+		substitution_values=substitution_values,
 	)
 
 
@@ -581,8 +641,17 @@ def _save_qc_record(
 	total_participants: int,
 	participant_ids: list | None = None,
 	qc_cohort: list | None = None,
+	qc_config_path: str | None = None,
+	substitution_values: dict | None = None,
 ) -> None:
-	_record_all_qc_tasks(participant_id, session_id, qc_pipeline, qc_tasks)
+	_record_all_qc_tasks(
+		participant_id,
+		session_id,
+		qc_pipeline,
+		qc_tasks,
+		qc_config_path=qc_config_path,
+		substitution_values=substitution_values,
+	)
 	if qc_cohort and SessionManager.all_qc_cohort_pages_complete_for_tasks(qc_tasks, qc_cohort):
 		SessionManager.set_current_page(total_participants + 1)
 	elif not qc_cohort and participant_ids and session_id:
@@ -599,7 +668,9 @@ def _save_qc_record(
 
 def _record_qc_for_current_participant(participant_id: str, session_id: str,
 										 qc_pipeline: str, qc_task: str,
-										 rating: str, notes: str) -> None:
+										 rating: str, notes: str,
+										 task_id: str | None = None,
+										 run_id: str | None = None) -> None:
 	"""Save a QC record for the current participant without navigating."""
 	now = datetime.now()
 	timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
@@ -614,5 +685,7 @@ def _record_qc_for_current_participant(participant_id: str, session_id: str,
 		rater_fatigue=SessionManager.get_rater_fatigue(),
 		final_qc=rating,
 		notes=notes,
+		task_id=task_id,
+		run_id=run_id,
 	)
 	SessionManager.add_qc_record(record)

--- a/ui/main.py
+++ b/ui/main.py
@@ -10,13 +10,16 @@ from components.qc_viewer import AUTOPLAY_RUN_CTX_KEY
 from managers.session_manager import SessionManager
 from constants import SESSION_KEYS
 from views.sidebar_cohort_nav import render_sidebar_cohort_subjects
-from utils.cohort import (
-    build_qc_cohort,
+from utils.bids import (
     normalize_participant_id_bids as _normalize_participant_id,
     normalize_session_id_bids as _normalize_session_id,
     parse_session_list as _parse_session_list,
+)
+from utils.cohort import (
+    build_qc_cohort,
     participant_ids_in_cohort_order,
 )
+from utils.config import build_substitution_values
 
 
 def parse_args(args=None):
@@ -164,6 +167,12 @@ def main():
         participant_id = entry["participant_id"]
         session_id = entry["session_id"]
 
+    substitution_values = (
+        build_substitution_values(participant_id, session_id)
+        if participant_id is not None
+        else None
+    )
+
     if (
         participant_id is not None
         and qc_cohort
@@ -178,6 +187,8 @@ def main():
             "total_participants": total_participants,
             "qc_cohort": qc_cohort,
             "participant_ids": participant_ids,
+            "qc_config_path": qc_config_path,
+            "substitution_values": substitution_values,
         }
     else:
         st.session_state.pop(AUTOPLAY_RUN_CTX_KEY, None)
@@ -204,6 +215,8 @@ def main():
             "qc_tasks": qc_tasks,
             "participant_ids": participant_ids,
             "qc_cohort": qc_cohort,
+            "qc_config_path": qc_config_path,
+            "substitution_values": substitution_values,
         }
         if on_qc_viewer_page
         else None,

--- a/ui/managers/session_manager.py
+++ b/ui/managers/session_manager.py
@@ -1,4 +1,5 @@
 """Session state management for QC-Studio UI."""
+
 import streamlit as st
 from constants import (
     DEFAULT_PANELS,
@@ -7,13 +8,7 @@ from constants import (
     DEFAULT_MONTAGE_MAX_COLS,
     QC_RATINGS,
 )
-
-
-def _bare_bids_id(val: str, prefix: str) -> str:
-    val = str(val)
-    if val.startswith(prefix):
-        val = val[len(prefix) :]
-    return val.lstrip("0") or "0"
+from utils.cohort import bare_bids_id
 
 
 class SessionManager:
@@ -132,8 +127,8 @@ class SessionManager:
         pipe = record.pipeline if hasattr(record, "pipeline") else record.get("pipeline", "")
         task = record.qc_task if hasattr(record, "qc_task") else record.get("qc_task", "")
         return (
-            _bare_bids_id(pid, "sub-"),
-            _bare_bids_id(sid, "ses-"),
+            bare_bids_id(pid, "sub-"),
+            bare_bids_id(sid, "ses-"),
             str(pipe),
             str(task),
         )
@@ -291,15 +286,15 @@ class SessionManager:
         during a session (e.g. sub-QPNNC000421 / ses-01) match records loaded
         from a CSV (e.g. QPNNC000421 / 1).
         """
-        bare_pid = _bare_bids_id(participant_id, "sub-")
-        bare_sid = _bare_bids_id(session_id, "ses-")
+        bare_pid = bare_bids_id(participant_id, "sub-")
+        bare_sid = bare_bids_id(session_id, "ses-")
         for record in reversed(SessionManager.get_qc_records()):
             rec_pid = record.participant_id if hasattr(record, 'participant_id') else record.get('participant_id', '')
             rec_sid = record.session_id if hasattr(record, 'session_id') else record.get('session_id', '')
             rec_task = record.qc_task if hasattr(record, 'qc_task') else record.get('qc_task', '')
             if qc_task is not None and str(rec_task) != str(qc_task):
                 continue
-            if _bare_bids_id(str(rec_pid), "sub-") == bare_pid and _bare_bids_id(str(rec_sid), "ses-") == bare_sid:
+            if bare_bids_id(str(rec_pid), "sub-") == bare_pid and bare_bids_id(str(rec_sid), "ses-") == bare_sid:
                 return record
         return None
 

--- a/ui/managers/session_manager.py
+++ b/ui/managers/session_manager.py
@@ -8,7 +8,7 @@ from constants import (
     DEFAULT_MONTAGE_MAX_COLS,
     QC_RATINGS,
 )
-from utils.cohort import bare_bids_id
+from utils.bids import bare_bids_id
 
 
 class SessionManager:

--- a/ui/tests/test_bids.py
+++ b/ui/tests/test_bids.py
@@ -1,0 +1,129 @@
+"""Tests for BIDS filename helpers."""
+from pathlib import Path
+
+import pytest
+
+from utils.bids import (
+    bare_bids_id,
+    extract_bids_entities_from_path,
+    extract_unique_task_run_from_paths,
+    normalize_participant_id_bids,
+    normalize_session_id_bids,
+    parse_session_list,
+)
+
+
+class TestBidsIdHelpers:
+    """Test BIDS ID normalization helpers."""
+
+    def test_bare_bids_id_strips_prefix_and_leading_zeros(self):
+        assert bare_bids_id("sub-0001", "sub-") == "1"
+        assert bare_bids_id("ses-01", "ses-") == "1"
+
+    def test_normalize_participant_id_bids_adds_missing_prefix(self):
+        assert normalize_participant_id_bids("CMH0001") == "sub-CMH0001"
+        assert normalize_participant_id_bids("sub-CMH0001") == "sub-CMH0001"
+
+    def test_normalize_session_id_bids_adds_missing_prefix(self):
+        assert normalize_session_id_bids("1") == "ses-01"
+        assert normalize_session_id_bids("BL") == "ses-BL"
+        assert normalize_session_id_bids("ses-02") == "ses-02"
+
+    def test_normalize_session_id_bids_rejects_empty_value(self):
+        with pytest.raises(ValueError):
+            normalize_session_id_bids("")
+
+    def test_parse_session_list_returns_unique_normalized_sessions(self):
+        assert parse_session_list("1,ses-02,1") == ["ses-01", "ses-02"]
+        assert parse_session_list("") is None
+
+
+class TestExtractBidsEntitiesFromPath:
+    """Test BIDS entity extraction from path-like filenames."""
+
+    def test_extracts_all_entities_from_svg_path(self):
+        entities = extract_bids_entities_from_path(
+            "figures/sub-01_ses-01_task-rest_run-02_desc-montage.svg"
+        )
+
+        assert entities == {
+            "sub": "01",
+            "ses": "01",
+            "task": "rest",
+            "run": "02",
+            "desc": "montage",
+        }
+
+    def test_extracts_entities_from_multi_suffix_path_without_file_existing(self):
+        entities = extract_bids_entities_from_path(
+            "sub-01/ses-01/func/sub-01_ses-01_task-rest_run-02_bold.nii.gz"
+        )
+
+        assert entities["sub"] == "01"
+        assert entities["ses"] == "01"
+        assert entities["task"] == "rest"
+        assert entities["run"] == "02"
+
+    def test_returns_missing_entities_absent(self):
+        entities = extract_bids_entities_from_path("sub-01_ses-01_desc-montage.svg")
+
+        assert entities.get("task") is None
+        assert entities.get("run") is None
+
+    def test_accepts_path_objects(self):
+        entities = extract_bids_entities_from_path(
+            Path("sub-01_ses-01_task-rest_run-02_desc-montage.svg")
+        )
+
+        assert entities["task"] == "rest"
+        assert entities["run"] == "02"
+
+    def test_empty_path_returns_empty_dict(self):
+        assert extract_bids_entities_from_path(None) == {}
+        assert extract_bids_entities_from_path("") == {}
+
+
+class TestExtractUniqueTaskRunFromPaths:
+    """Test extracting one task/run pair from one or more paths."""
+
+    def test_extracts_unique_task_run_from_single_path(self):
+        task_id, run_id = extract_unique_task_run_from_paths(
+            "sub-01_ses-01_task-rest_run-02_desc-montage.svg"
+        )
+
+        assert task_id == "task-rest"
+        assert run_id == "run-02"
+
+    def test_extracts_unique_task_run_from_multiple_matching_paths(self):
+        task_id, run_id = extract_unique_task_run_from_paths([
+            "sub-01_ses-01_task-rest_run-02_desc-sdc.svg",
+            "sub-01_ses-01_task-rest_run-02_desc-coreg.svg",
+        ])
+
+        assert task_id == "task-rest"
+        assert run_id == "run-02"
+
+    def test_returns_none_for_conflicting_runs(self):
+        task_id, run_id = extract_unique_task_run_from_paths([
+            "sub-01_ses-01_task-rest_run-01_desc-sdc.svg",
+            "sub-01_ses-01_task-rest_run-02_desc-sdc.svg",
+        ])
+
+        assert task_id is None
+        assert run_id is None
+
+    def test_extracts_task_without_run(self):
+        task_id, run_id = extract_unique_task_run_from_paths(
+            "sub-01_ses-01_task-rest_desc-montage.svg"
+        )
+
+        assert task_id == "task-rest"
+        assert run_id is None
+
+    def test_returns_none_for_missing_entities(self):
+        task_id, run_id = extract_unique_task_run_from_paths(
+            "sub-01_ses-01_desc-montage.svg"
+        )
+
+        assert task_id is None
+        assert run_id is None

--- a/ui/tests/test_qc_viewer.py
+++ b/ui/tests/test_qc_viewer.py
@@ -1,6 +1,8 @@
 """Tests for qc_viewer helper utilities."""
+import json
 
-from components.qc_viewer import _clean_filename
+from components import qc_viewer
+from components.qc_viewer import _clean_filename, _record_all_qc_tasks
 
 
 class TestCleanFilename:
@@ -20,3 +22,45 @@ class TestCleanFilename:
         """Fallback path should remove synthetic image-type suffixes."""
         filename = "summary_plot_png"
         assert _clean_filename(filename) == "summary_plot"
+
+
+class TestRecordAllQcTasks:
+    """Tests for recording QC metadata from configured montage paths."""
+
+    def test_records_task_and_run_from_svg_montage_path(self, monkeypatch, temp_dir):
+        """Saved QC records should include unambiguous task/run metadata."""
+        qc_config_path = temp_dir / "qc.json"
+        qc_config_path.write_text(
+            json.dumps({
+                "func_wf_qc": {
+                    "svg_montage_path": (
+                        "derivatives/sub-01/ses-01/figures/"
+                        "sub-01_ses-01_task-rest_run-02_desc-montage.svg"
+                    )
+                }
+            })
+        )
+        session_state = {
+            "qc_records": [],
+            "rating_version": 0,
+            "notes_version": 0,
+            "qc_rating_func_wf_qc_0": "PASS",
+            "qc_notes_func_wf_qc_0": "looks good",
+            "rater_id": "test_rater",
+            "rater_experience": "Expert",
+            "rater_fatigue": "Rested",
+        }
+        monkeypatch.setattr(qc_viewer.st, "session_state", session_state)
+
+        _record_all_qc_tasks(
+            participant_id="sub-01",
+            session_id="ses-01",
+            qc_pipeline="fmriprep",
+            qc_tasks=["func_wf_qc"],
+            qc_config_path=qc_config_path,
+        )
+
+        assert len(session_state["qc_records"]) == 1
+        record = session_state["qc_records"][0]
+        assert record.task_id == "task-rest"
+        assert record.run_id == "run-02"

--- a/ui/tests/test_ui.py
+++ b/ui/tests/test_ui.py
@@ -52,7 +52,7 @@ class TestParseArgs:
             '--qc_json', '/path/to/qc_config.json'
         ])
         
-        assert args.session_list == 'Baseline'
+        assert args.session_list is None
 
     def test_parse_args_missing_required_argument(self):
         """Test parsing with missing required argument."""

--- a/ui/utils/bids.py
+++ b/ui/utils/bids.py
@@ -54,7 +54,7 @@ def extract_bids_entities_from_path(path: str | Path | None) -> dict[str, str]:
 
 	path = Path(path)
 	stem = path.name
-	for suffix in path.suffixes:
+	for suffix in reversed(path.suffixes):
 		stem = stem.removesuffix(suffix)
 
 	entities: dict[str, str] = {}

--- a/ui/utils/bids.py
+++ b/ui/utils/bids.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+
+def bare_bids_id(val: str, prefix: str) -> str:
+	val = str(val)
+	if val.startswith(prefix):
+		val = val[len(prefix) :]
+	return val.lstrip("0") or "0"
+
+
+def normalize_participant_id_bids(pid: str) -> str:
+	p = str(pid).strip()
+	return p if p.startswith("sub-") else f"sub-{p}"
+
+
+def normalize_session_id_bids(sid: str) -> str:
+	s = str(sid).strip()
+	if not s:
+		raise ValueError("session id cannot be empty")
+	if s.startswith("ses-"):
+		return s
+	if s.isdigit():
+		return f"ses-{int(s):02d}"
+	return f"ses-{s}"
+
+
+def parse_session_list(raw: str | None) -> list[str] | None:
+	"""Return ordered unique BIDS session ids from CLI ``--session_list``.
+
+	Returns None for single-session datasets (no session label).
+	"""
+	if raw is None or str(raw).strip() == "":
+		return None
+	parts = [p.strip() for p in str(raw).strip().split(",") if p.strip()]
+	if not parts:
+		return None
+	seen: list[str] = []
+	for p in parts:
+		norm = normalize_session_id_bids(p)
+		if norm not in seen:
+			seen.append(norm)
+	return seen or None
+
+
+def extract_bids_entities_from_path(path: str | Path | None) -> dict[str, str]:
+	"""Return BIDS entities parsed from a path-like filename.
+
+	The path does not need to exist; this helper only inspects the filename.
+	For example, ``sub-01_ses-01_task-rest_run-02_desc-sdc_bold.svg`` returns
+	``{"sub": "01", "ses": "01", "task": "rest", "run": "02", "desc": "sdc"}``.
+	"""
+	if not path:
+		return {}
+
+	path = Path(path)
+	stem = path.name
+	for suffix in path.suffixes:
+		stem = stem.removesuffix(suffix)
+
+	entities: dict[str, str] = {}
+	for part in stem.split("_"):
+		if "-" not in part:
+			continue
+		key, value = part.split("-", 1)
+		if key and value:
+			entities[key] = value
+
+	return entities
+
+
+def format_bids_entity(key: str, value: str | None) -> str | None:
+	if not value:
+		return None
+	value = str(value)
+	return value if value.startswith(f"{key}-") else f"{key}-{value}"
+
+
+def extract_unique_task_run_from_paths(paths) -> tuple[str | None, str | None]:
+	"""Return task_id/run_id when paths have one unambiguous task/run pair."""
+	if not paths:
+		return None, None
+
+	if isinstance(paths, (str, Path)):
+		paths = [paths]
+
+	pairs = set()
+	for path in paths:
+		entities = extract_bids_entities_from_path(path)
+		task = entities.get("task")
+		run = entities.get("run")
+		if task or run:
+			pairs.add((task, run))
+
+	if len(pairs) != 1:
+		return None, None
+
+	task, run = pairs.pop()
+	return format_bids_entity("task", task), format_bids_entity("run", run)

--- a/ui/utils/cohort.py
+++ b/ui/utils/cohort.py
@@ -6,43 +6,12 @@ import pandas as pd
 from constants import QC_RATINGS
 
 
-def bare_bids_id(val: str, prefix: str) -> str:
-	val = str(val)
-	if val.startswith(prefix):
-		val = val[len(prefix) :]
-	return val.lstrip("0") or "0"
-
-
-def normalize_participant_id_bids(pid: str) -> str:
-	p = str(pid).strip()
-	return p if p.startswith("sub-") else f"sub-{p}"
-
-
-def normalize_session_id_bids(sid: str) -> str:
-	s = str(sid).strip()
-	if not s:
-		raise ValueError("session id cannot be empty")
-	if s.startswith("ses-"):
-		return s
-	if s.isdigit():
-		return f"ses-{int(s):02d}"
-	return f"ses-{s}"
-def parse_session_list(raw: str | None) -> list[str] | None:
-	"""Return ordered unique BIDS session ids from CLI ``--session_list``.
-
-	Returns None for single-session datasets (no session label).
-	"""
-	if raw is None or str(raw).strip() == "":
-		return None
-	parts = [p.strip() for p in str(raw).strip().split(",") if p.strip()]
-	if not parts:
-		return None
-	seen: list[str] = []
-	for p in parts:
-		norm = normalize_session_id_bids(p)
-		if norm not in seen:
-			seen.append(norm)
-	return seen or None
+from utils.bids import (
+    bare_bids_id,
+    normalize_participant_id_bids,
+    normalize_session_id_bids,
+    parse_session_list,
+)
 
 
 def build_qc_cohort(participants_df: pd.DataFrame, session_ids: list[str] | None) -> list[dict]:

--- a/ui/views/landing_page.py
+++ b/ui/views/landing_page.py
@@ -10,9 +10,9 @@ from managers.session_manager import SessionManager
 from models import QCRecord
 from managers.panel_layout_manager import PanelLayoutManager
 from managers.niivue_viewer_manager import NiivueViewerManager
+from utils.bids import bare_bids_id
 from utils.config import list_qc_tasks_from_json, parse_qc_config
 from utils.cohort import (
-	bare_bids_id,
 	build_qc_cohort,
 	count_complete_cohort_pages,
 	decided_rating_keys_from_df,


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "Closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #42 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

## Summary
- Parse BIDS task/run entities from svg_montage_path
- Store unambiguous task_id and run_id on QCRecord creation
- Keep existing behavior when task/run are missing or ambiguous
- Move shared BIDS ID helpers into utils.bids

## Tests
- .venv/bin/python -m pytest ui/tests/test_bids.py ui/tests/test_qc_viewer.py ui/tests/test_session_manager.py ui/tests/test_utils.py ui/tests/test_ui.py

<!-- To be checked off by reviewers -->
## Checklist (for reviewers)
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (e.g. `[BUG]`, `[DOC]`, `[ENH]`, `[MAINT]`)\
Refer to [NumPy Development Guide](https://numpy.org/doc/stable/dev/development_workflow.html#writing-the-commit-message) for a full list
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions