### PR TITLE
[MAINT] Fix broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web-based quality control (QC) application for neuroimaging data. QC-Studio allows raters to visualize and assess MRI data, SVG montages, and IQM metrics in an interactive Streamlit interface.
 
-[See design overview →](docs/dev_plan.md)
+[See design overview →](docs/DEV_PLAN.md)
 
 ## 🎯 Goals
 

--- a/docs/DEV_PLAN.md
+++ b/docs/DEV_PLAN.md
@@ -1,8 +1,7 @@
 # QC-Studio MVP Scope
 
 ## Design Overview
-![overview](assets/nipoppy-qc-studio_overview.jpg)
-
+![overview](../assets/nipoppy-qc-studio_overview.jpg)
 
 ## Key requirements: datatypes / formats
 - Support visualization of curated data


### PR DESCRIPTION
## Summary
- Fix README design overview link casing to match docs/DEV_PLAN.md
- Fix DEV_PLAN overview image path relative to the docs directory

Closes #64